### PR TITLE
Add anthropic-version header

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -30,7 +30,8 @@ claudeR <- function(prompt, model = "claude-2", max_tokens,
   url <- "https://api.anthropic.com/v1/complete"
   headers <- add_headers(
     "X-API-Key" = api_key,
-    "Content-Type" = "application/json"
+    "Content-Type" = "application/json",
+    "anthropic-version" = "2023-06-01"
   )
 
   # Build the prompt with the User/Assistant convention


### PR DESCRIPTION
Thanks for putting together this package. I was getting an error message that `"anthropic-version: header is required"`. Looking at the [Anthropic python API library](https://github.com/anthropics/anthropic-sdk-python), it looks like `"anthropic-version" = "2023-06-01"` is the default, so have made a minor edit to add this to the headers so the function runs.